### PR TITLE
This adds a class for a collection response holding only IDs

### DIFF
--- a/vendorflow-jsonapi-model/src/main/java/co/vendorflow/oss/jsonapi/model/request/JsonApiDataCollectionResourceIds.java
+++ b/vendorflow-jsonapi-model/src/main/java/co/vendorflow/oss/jsonapi/model/request/JsonApiDataCollectionResourceIds.java
@@ -1,0 +1,18 @@
+package co.vendorflow.oss.jsonapi.model.request;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import co.vendorflow.oss.jsonapi.model.resource.JsonApiResourceId;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class JsonApiDataCollectionResourceIds<M> extends JsonApiDataTopLevel<Collection<JsonApiResourceId>, M> {
+    {
+        data = new ArrayList<>();
+    }
+}


### PR DESCRIPTION
According to [https://jsonapi.org/format/1.1/#document-top-level], the
top-level `data` member may consist of an array of resource IDs (which
are structurally identical to a resource object with all optional
fields omitted). This is useful, for example, as a return value for
identifying some objects (Dispatches) by relationship without pulling
their properties separately.

[version patch]