### PR TITLE
Skip trying to write if targetDirectory is null

### DIFF
--- a/vendorflow-jsonapi-groovy-annotation-processor/src/main/groovy/co/vendorflow/oss/jsonapi/groovy/transform/JsonApiTypeAstTransformation.groovy
+++ b/vendorflow-jsonapi-groovy-annotation-processor/src/main/groovy/co/vendorflow/oss/jsonapi/groovy/transform/JsonApiTypeAstTransformation.groovy
@@ -47,9 +47,6 @@ class JsonApiTypeAstTransformation extends AbstractASTTransformation {
         init(nodes, source)
         ClassNode resource = nodes[1] as ClassNode
 
-        var outDir = source.AST.unit.config.targetDirectory
-        var spiFile = outDir.toPath().resolve(SPI_PATH).toFile()
-
         var trci = trci(nodes[0] as AnnotationNode, resource)
 
         var components = buildTypeComponents(trci)
@@ -63,6 +60,14 @@ class JsonApiTypeAstTransformation extends AbstractASTTransformation {
         var trcn = buildRegistrationClass(trci)
         source.AST.addClass(trcn)
 
+
+        var outDir = source.AST.unit.config.targetDirectory
+        if (!outDir) {
+            // transformation is being run "speculatively" and not as part of a live build, so skip processing.
+            return
+        }
+
+        var spiFile = outDir.toPath().resolve(SPI_PATH).toFile()
         synchronized (JsonApiTypeAstTransformation) { // file locks apply to the entire JVM
             try (def chan = channelFor(spiFile)) {
                 chan.lock(0, MAX_VALUE, true)


### PR DESCRIPTION
Groovy-Eclipse can invoke ASTTs outside of a live build cycle, and in
such a case the targetDirectory may not be set. In such a case, still
modify the AST to present the additional class members, but don't try
to update the SPI index.

https://github.com/groovy/groovy-eclipse/issues/1394

[version patch]