### PR TITLE
Add static FooResource.id(Object) method

### DIFF
--- a/vendorflow-jsonapi-groovy-annotation-processor/src/main/groovy/dsld/jsonapitype_members.dsld
+++ b/vendorflow-jsonapi-groovy-annotation-processor/src/main/groovy/dsld/jsonapitype_members.dsld
@@ -1,0 +1,10 @@
+// https://github.com/groovy/groovy-eclipse/wiki/DSL-Descriptors
+package dsld
+
+contribute(currentType(annotations: annotatedBy('co.vendorflow.oss.jsonapi.model.JsonApiType'))) {
+    for (annotationNode in annotations) {
+        property name: 'TYPE', type: String, isStatic: true, readOnly: true
+        delegatesTo type: 'co.vendorflow.oss.jsonapi.model.resource.JsonApiResource'
+        method name: 'id', isStatic: true, type: 'co.vendorflow.oss.jsonapi.model.resource.JsonApiResourceId', params: [id: Object]
+    }
+}

--- a/vendorflow-jsonapi-groovy-annotation-processor/src/test/groovy/co/vendorflow/oss/jsonapi/groovy/transform/JsonApiTypeAstTransformationTest.groovy
+++ b/vendorflow-jsonapi-groovy-annotation-processor/src/test/groovy/co/vendorflow/oss/jsonapi/groovy/transform/JsonApiTypeAstTransformationTest.groovy
@@ -1,6 +1,7 @@
 package co.vendorflow.oss.jsonapi.groovy.transform
 
 import co.vendorflow.oss.jsonapi.jackson.JsonApiTypeIdResolver
+import co.vendorflow.oss.jsonapi.model.resource.JsonApiResourceId
 import co.vendorflow.oss.jsonapi.model.resource.JsonApiType
 import spock.lang.Specification
 
@@ -13,6 +14,12 @@ class JsonApiTypeAstTransformationTest extends Specification {
         expect:
         TYPE_NAME == ExplicitResource.TYPE
         TYPE_NAME == new ExplicitResource().type
+    }
+
+
+    def 'static id method is added to the annotated class'() {
+        expect:
+        JsonApiResourceId.of(TYPE_NAME, '1234') == ExplicitResource.id(1234)
     }
 
 

--- a/vendorflow-jsonapi-java-annotation-processor/src/main/resources/co/vendorflow/oss/jsonapi/processor/templates/JsonApiResource.ftl
+++ b/vendorflow-jsonapi-java-annotation-processor/src/main/resources/co/vendorflow/oss/jsonapi/processor/templates/JsonApiResource.ftl
@@ -5,6 +5,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.Valid;
 
 import co.vendorflow.oss.jsonapi.model.resource.JsonApiResource;
+import co.vendorflow.oss.jsonapi.model.resource.JsonApiResourceId;
 import co.vendorflow.oss.jsonapi.model.resource.JsonApiType;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -21,6 +22,8 @@ public final class ${rci.simpleName}
   public static final String TYPE = "${rci.jsonApiType}";
 
   @Override public String getType() { return TYPE; }
+  
+  public static JsonApiResourceId id(Object id) { return JsonApiResourceId.of(TYPE, id); }
   
   @Override public void setAttributes(${attr.qualifiedName} value) { super.setAttributes(value); }
   <#if !rci.attributesNullable>

--- a/vendorflow-jsonapi-java-annotation-processor/src/test/groovy/co/vendorflow/oss/jsonapi/processor/AttributesToDtoProcessorTest.groovy
+++ b/vendorflow-jsonapi-java-annotation-processor/src/test/groovy/co/vendorflow/oss/jsonapi/processor/AttributesToDtoProcessorTest.groovy
@@ -122,6 +122,9 @@ class AttributesToDtoProcessorTest extends Specification {
         dto.toString().contains('id=1234')
 
         and:
+        JsonApiResourceId.of('quuxes', '9876') == resourceClass.getDeclaredMethod('id', Object).invoke(null, 9876)
+
+        and:
         def spiLines = compilation
             .generatedFile(CLASS_OUTPUT, 'META-INF/services/co.vendorflow.oss.jsonapi.jackson.JsonApiTypeRegistration').get()
             .openReader(false)

--- a/vendorflow-jsonapi-model/src/main/java/co/vendorflow/oss/jsonapi/model/resource/JsonApiResourceId.java
+++ b/vendorflow-jsonapi-model/src/main/java/co/vendorflow/oss/jsonapi/model/resource/JsonApiResourceId.java
@@ -12,7 +12,7 @@ public final class JsonApiResourceId {
         return new StringBuilder(type).append('/').append(id).toString();
     }
 
-    public static JsonApiResourceId of(String type, String id) {
-        return new JsonApiResourceId(type, id);
+    public static JsonApiResourceId of(String type, Object id) {
+        return new JsonApiResourceId(type, String.valueOf(id));
     }
 }


### PR DESCRIPTION
This makes it easier to retrieve a list of IDs (strings, numbers,
whatever) and turn them into JsonApiResourceIds via a method reference.

[version patch]