### PR TITLE
Allow extends JsonApiDocument on a fold

### DIFF
--- a/vendorflow-jsonapi-groovy-spring-webmvc/src/main/java/co/vendorflow/oss/jsonapi/groovy/spring/webmvc/JsonApiSpringWebMvcExtensions.java
+++ b/vendorflow-jsonapi-groovy-spring-webmvc/src/main/java/co/vendorflow/oss/jsonapi/groovy/spring/webmvc/JsonApiSpringWebMvcExtensions.java
@@ -91,12 +91,13 @@ public final class JsonApiSpringWebMvcExtensions {
      * @param self the receiver
      * @return the {@code ResponseEntity} in the Right or a {@code ResponseEntity} containing the {@code errors} in the Left
      */
+    @SuppressWarnings("unchecked") // because the ResponseEntity's body is not rewritable
     public static <D>
     ResponseEntity<JsonApiDocument<D, ?>>
     foldErrorsAndResponseEntity(
-            Either<JsonApiErrorDocument<D>, ResponseEntity<JsonApiDocument<D, ?>>> self
+            Either<JsonApiErrorDocument<D>, ResponseEntity<? extends JsonApiDocument<D, ?>>> self
     ) {
-        return self.getOrElseGet(JsonApiSpringWebMvcExtensions::toResponseEntity);
+        return (ResponseEntity<JsonApiDocument<D, ?>>) self.getOrElseGet(JsonApiSpringWebMvcExtensions::toResponseEntity);
     }
 
 


### PR DESCRIPTION
Since this operation collapses a maybe-error and a maybe-value, we can
consume any document type on the Right side. This will nearly always
be a JsonApiDataDocument, but pipelines might produce ResponseEntity
objects with custom error enhancements.

[version patch]