### PR TITLE
Support "latest source", make base class package-private

### DIFF
--- a/vendorflow-jsonapi-java-annotation-processor/src/main/java/co/vendorflow/oss/jsonapi/processor/AttributesToDtoProcessor.java
+++ b/vendorflow-jsonapi-java-annotation-processor/src/main/java/co/vendorflow/oss/jsonapi/processor/AttributesToDtoProcessor.java
@@ -2,21 +2,18 @@ package co.vendorflow.oss.jsonapi.processor;
 
 import static co.vendorflow.oss.jsonapi.processor.support.ResourceClassInfo.JAA_CLASS_NAME;
 import static java.util.stream.Collectors.toMap;
-import static javax.lang.model.SourceVersion.RELEASE_9;
 
 import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 
 import co.vendorflow.oss.jsonapi.processor.support.ResourceClassInfo;
 
 @SupportedAnnotationTypes("co.vendorflow.oss.jsonapi.model.resource.JsonApiAttributes")
-@SupportedSourceVersion(RELEASE_9)
 public class AttributesToDtoProcessor extends FreemarkerProcessor {
 
     @Override

--- a/vendorflow-jsonapi-java-annotation-processor/src/main/java/co/vendorflow/oss/jsonapi/processor/FreemarkerProcessor.java
+++ b/vendorflow-jsonapi-java-annotation-processor/src/main/java/co/vendorflow/oss/jsonapi/processor/FreemarkerProcessor.java
@@ -1,6 +1,6 @@
 package co.vendorflow.oss.jsonapi.processor;
 
-import static freemarker.template.Configuration.VERSION_2_3_31;
+import static freemarker.template.Configuration.VERSION_2_3_32;
 import static javax.tools.Diagnostic.Kind.ERROR;
 
 import java.io.IOException;
@@ -8,20 +8,29 @@ import java.io.StringWriter;
 import java.util.Map;
 
 import javax.annotation.processing.AbstractProcessor;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
 
 import freemarker.cache.ClassTemplateLoader;
 import freemarker.template.Configuration;
 import freemarker.template.TemplateException;
 
-public abstract class FreemarkerProcessor extends AbstractProcessor {
+abstract class FreemarkerProcessor extends AbstractProcessor {
     private static final Configuration FREEMARKER = freemarker();
 
     private static Configuration freemarker() {
-        var cfg = new Configuration(VERSION_2_3_31);
+        var cfg = new Configuration(VERSION_2_3_32);
         cfg.setTemplateLoader(new ClassTemplateLoader(FreemarkerProcessor.class, "templates"));
         cfg.setDefaultEncoding("UTF-8");
         return cfg;
+    }
+
+    /**
+     * The processors in this library do not inspect the source code directly.
+     */
+    @Override
+    public final SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
     }
 
     protected String processFreemarker(String templateBase, Map<String, ?> model) throws IOException, TemplateException {

--- a/vendorflow-jsonapi-java-annotation-processor/src/main/java/co/vendorflow/oss/jsonapi/processor/TypeRegistrationProcessor.java
+++ b/vendorflow-jsonapi-java-annotation-processor/src/main/java/co/vendorflow/oss/jsonapi/processor/TypeRegistrationProcessor.java
@@ -1,6 +1,5 @@
 package co.vendorflow.oss.jsonapi.processor;
 
-import static javax.lang.model.SourceVersion.RELEASE_9;
 import static javax.tools.Diagnostic.Kind.ERROR;
 import static javax.tools.Diagnostic.Kind.NOTE;
 import static javax.tools.StandardLocation.CLASS_OUTPUT;
@@ -13,7 +12,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
@@ -24,7 +22,6 @@ import co.vendorflow.oss.jsonapi.model.resource.JsonApiType;
 import co.vendorflow.oss.jsonapi.processor.support.TypeRegistrationClassInfo;
 
 @SupportedAnnotationTypes("co.vendorflow.oss.jsonapi.model.resource.JsonApiType")
-@SupportedSourceVersion(RELEASE_9)
 public class TypeRegistrationProcessor extends FreemarkerProcessor {
     private static final String JAT_CLASS_NAME = JsonApiType.class.getName();
 


### PR DESCRIPTION
[version minor] because FreemarkerProcessor is removed from public